### PR TITLE
Ignore errors on init to allow deployment to AWS Elastic Beanstalk

### DIFF
--- a/elasticache_pyclient/__init__.py
+++ b/elasticache_pyclient/__init__.py
@@ -1,4 +1,7 @@
 #! /usr/bin/env python
 
-__version__ = "1.0"
-from memcache_client import MemcacheClient
+__version__ = "1.0.1"
+try:
+    from memcache_client import MemcacheClient
+except ImportError, e:
+    pass


### PR DESCRIPTION
Example error log from trying to deploy on Elastic Beanstalk:

Requirement already satisfied (use --upgrade to upgrade): flask in /opt/python/run/venv/lib/python2.7/site-packages (from -r /opt/python/ondeck/app/requirements.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): boto in /opt/python/run/venv/lib/python2.7/site-packages (from -r /opt/python/ondeck/app/requirements.txt (line 2))
Downloading/unpacking python-memcached (from -r /opt/python/ondeck/app/requirements.txt (line 3))
Downloading python-memcached-1.53.tar.gz
Running setup.py egg_info for package python-memcached

warning: no files found matching '_.rst'
warning: no files found matching '_.txt'
warning: no files found matching 'MakeFile'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '.gitignore' found anywhere in distribution
warning: no previously-included files matching '.DS_Store' found anywhere in distribution
Downloading/unpacking hash-ring (from -r /opt/python/ondeck/app/requirements.txt (line 4))
Downloading hash_ring-1.3.1.tar.gz
Running setup.py egg_info for package hash-ring

Downloading/unpacking elasticache-pyclient (from -r /opt/python/ondeck/app/requirements.txt (line 5))
Downloading elasticache_pyclient-1.0.tar.gz
Running setup.py egg_info for package elasticache-pyclient
Traceback (most recent call last):
File "<string>", line 16, in <module>
File "/opt/python/run/venv/build/elasticache-pyclient/setup.py", line 6, in <module>
VERSION = **import**(PACKAGE).**version**
File "elasticache_pyclient/**init**.py", line 4, in <module>
from memcache_client import MemcacheClient
File "elasticache_pyclient/memcache_client.py", line 10, in <module>
import hash_ring
ImportError: No module named hash_ring
Complete output from command python setup.py egg_info:
Traceback (most recent call last):

File "<string>", line 16, in <module>

File "/opt/python/run/venv/build/elasticache-pyclient/setup.py", line 6, in <module>

VERSION = **import**(PACKAGE).**version**

File "elasticache_pyclient/**init**.py", line 4, in <module>

from memcache_client import MemcacheClient

File "elasticache_pyclient/memcache_client.py", line 10, in <module>

import hash_ring

ImportError: No module named hash_ring
